### PR TITLE
Added code for opt-in only telemetry

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -72,7 +72,10 @@ function init(context: types.IExtensionContext) {
         enabled: autoRun(state),
       };
     }, 'download',
-    'FNIS Integration', (props: IFNISProps) => toggleIntegration(context.api, props.gameMode),
+    'FNIS Integration', (props: IFNISProps) => {
+      toggleIntegration(context.api, props.gameMode)
+      context.api.events.emit('analytics-track-click-event', 'Dashboard', `FNIS ${props.enabled ? 'ON' : 'OFF'}`);
+    },
     (props: IFNISProps) => isSupported(props.gameMode),
     (t: TranslationFunction, props: IFNISProps) => (
       props.enabled ? t('Yes') : t('No')


### PR DESCRIPTION
This MR adds the code required for collecting telemetry in Vortex. 
This is going to be a totally optional opt-in system for users that want to help improve Vortex by providing us with anonymous usage data.